### PR TITLE
Add Content Patcher Harmony Patching fuctionality

### DIFF
--- a/BETAS/BETAS.cs
+++ b/BETAS/BETAS.cs
@@ -53,6 +53,7 @@ namespace BETAS
             helper.Events.GameLoop.DayStarted += this.OnDayStarted;
             helper.Events.GameLoop.UpdateTicked += this.OnUpdateTicked;
             helper.Events.Content.AssetRequested += this.OnAssetRequested;
+            helper.Events.Content.AssetsInvalidated += this.OnAssetsInvalidated;
             helper.Events.GameLoop.UpdateTicked += this.InitializePatcher;
             helper.Events.Multiplayer.ModMessageReceived += this.OnModMessageReceived;
             helper.Events.Multiplayer.PeerConnected += this.OnPeerConnected;
@@ -84,6 +85,14 @@ namespace BETAS
             if (e.NameWithoutLocale.IsEquivalentTo("Spiderbuttons.BETAS/HarmonyPatches"))
             {
                 e.LoadFrom(() => new List<DynamicPatch>(), AssetLoadPriority.Medium);
+            }
+        }
+
+        private void OnAssetsInvalidated(object? sender, AssetsInvalidatedEventArgs e)
+        {
+            if (e.NamesWithoutLocale.Any(asset => asset.IsEquivalentTo("Spiderbuttons.BETAS/HarmonyPatches")))
+            {
+                DynamicPatcher.Reset(ModManifest);
             }
         }
 
@@ -214,7 +223,10 @@ namespace BETAS
 
             if (e.Button == SButton.F6)
             {
-                Log.Warn(Game1.player.DailyLuck);
+                Log.Warn($"Location Display Name: {Game1.player.currentLocation.DisplayName}");
+                Log.Warn($"Player Display Name: {Game1.player.displayName}");
+                Log.Warn($"Magnifying Glass: {Game1.player.hasMagnifyingGlass}");
+                Log.Warn($"Cobmat Level: {Game1.player.CombatLevel}");
             }
 
             if (e.Button == SButton.F5)

--- a/BETAS/BETAS.cs
+++ b/BETAS/BETAS.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using BETAS.Attributes;
 using BETAS.Helpers;
+using BETAS.Models;
 using HarmonyLib;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -36,8 +37,10 @@ namespace BETAS
             var types = Assembly.GetExecutingAssembly().GetTypes();
             var methods = types.SelectMany(t => t.GetMethods())
                 .Where(m => !m.IsDefined(typeof(CompilerGeneratedAttribute), false));
-            
-            RegisterTriggers(ref types);
+
+            int tester = 4;
+            bool whether = false;
+            RegisterTriggers(ref types, ref tester, ref whether);
             RegisterActions(ref methods);
             RegisterQueries(ref methods);
             RegisterTokenizableStrings(ref methods);
@@ -48,6 +51,8 @@ namespace BETAS
             helper.Events.Input.ButtonPressed += this.OnButtonPressed;
             helper.Events.GameLoop.DayStarted += this.OnDayStarted;
             helper.Events.GameLoop.UpdateTicked += this.OnUpdateTicked;
+            helper.Events.Content.AssetRequested += this.OnAssetRequested;
+            helper.Events.GameLoop.UpdateTicked += this.InitializePatcher;
             helper.Events.Multiplayer.ModMessageReceived += this.OnModMessageReceived;
             helper.Events.Multiplayer.PeerConnected += this.OnPeerConnected;
             helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
@@ -71,6 +76,22 @@ namespace BETAS
             if (!Context.IsMainPlayer || !Context.IsMultiplayer) return;
             Cache ??= new MultiplayerNpcCache();
             Cache.UpdateCharacterList();
+        }
+        
+        private void OnAssetRequested(object? sender, AssetRequestedEventArgs e)
+        {
+            if (e.NameWithoutLocale.IsEquivalentTo("Spiderbuttons.BETAS/HarmonyPatches"))
+            {
+                e.LoadFrom(() => new List<DynamicPatch>(), AssetLoadPriority.Medium);
+            }
+        }
+
+        private void InitializePatcher(object? sender, UpdateTickedEventArgs e)
+        {
+            if (e.Ticks < 4 || DynamicPatcher.IsInitialized) return;
+            Log.Warn("Initializing patcher...");
+            DynamicPatcher.Initialize(ModManifest);
+            Helper.Events.GameLoop.UpdateTicked -= InitializePatcher;
         }
         
         private void OnUpdateTicked(object? sender, UpdateTickedEventArgs e)
@@ -147,7 +168,7 @@ namespace BETAS
             }
         }
 
-        private static void RegisterTriggers(ref Type[] types)
+        private static void RegisterTriggers(ref Type[] types, ref int test, ref bool whether)
         {
             foreach (var type in types)
             {
@@ -189,7 +210,7 @@ namespace BETAS
 
             if (e.Button == SButton.F5)
             {
-                //
+                Log.Warn(Game1.player.hasMagnifyingGlass);
             }
         }
     }

--- a/BETAS/BETAS.cs
+++ b/BETAS/BETAS.cs
@@ -37,11 +37,8 @@ namespace BETAS
             var types = Assembly.GetExecutingAssembly().GetTypes();
             var methods = types.SelectMany(t => t.GetMethods())
                 .Where(m => !m.IsDefined(typeof(CompilerGeneratedAttribute), false));
-
-            double tester = 4;
-            bool whether = false;
-            string msg = "www";
-            RegisterTriggers(ref types, ref tester, ref whether, ref msg);
+            
+            RegisterTriggers(ref types);
             RegisterActions(ref methods);
             RegisterQueries(ref methods);
             RegisterTokenizableStrings(ref methods);
@@ -178,11 +175,8 @@ namespace BETAS
             }
         }
 
-        private static void RegisterTriggers(ref Type[] types, ref double test, ref bool whether, ref string msg)
+        private static void RegisterTriggers(ref Type[] types)
         {
-            test += 0.5;
-            whether = false;
-            msg += "yeeeee";
             foreach (var type in types)
             {
                 if (!type.IsDefined(typeof(TriggerAttribute), false)) continue;
@@ -221,17 +215,9 @@ namespace BETAS
             if (!Context.IsWorldReady)
                 return;
 
-            if (e.Button == SButton.F6)
-            {
-                Log.Warn($"Location Display Name: {Game1.player.currentLocation.DisplayName}");
-                Log.Warn($"Player Display Name: {Game1.player.displayName}");
-                Log.Warn($"Magnifying Glass: {Game1.player.hasMagnifyingGlass}");
-                Log.Warn($"Cobmat Level: {Game1.player.CombatLevel}");
-            }
-
             if (e.Button == SButton.F5)
             {
-                Harmony.UnpatchAll(ModManifest.UniqueID + "_DynamicPatcher");
+                //
             }
         }
     }

--- a/BETAS/BETAS.cs
+++ b/BETAS/BETAS.cs
@@ -38,9 +38,10 @@ namespace BETAS
             var methods = types.SelectMany(t => t.GetMethods())
                 .Where(m => !m.IsDefined(typeof(CompilerGeneratedAttribute), false));
 
-            int tester = 4;
+            double tester = 4;
             bool whether = false;
-            RegisterTriggers(ref types, ref tester, ref whether);
+            string msg = "www";
+            RegisterTriggers(ref types, ref tester, ref whether, ref msg);
             RegisterActions(ref methods);
             RegisterQueries(ref methods);
             RegisterTokenizableStrings(ref methods);
@@ -168,8 +169,11 @@ namespace BETAS
             }
         }
 
-        private static void RegisterTriggers(ref Type[] types, ref int test, ref bool whether)
+        private static void RegisterTriggers(ref Type[] types, ref double test, ref bool whether, ref string msg)
         {
+            test += 0.5;
+            whether = false;
+            msg += "yeeeee";
             foreach (var type in types)
             {
                 if (!type.IsDefined(typeof(TriggerAttribute), false)) continue;
@@ -208,9 +212,14 @@ namespace BETAS
             if (!Context.IsWorldReady)
                 return;
 
+            if (e.Button == SButton.F6)
+            {
+                Log.Warn(Game1.player.DailyLuck);
+            }
+
             if (e.Button == SButton.F5)
             {
-                Log.Warn(Game1.player.hasMagnifyingGlass);
+                Harmony.UnpatchAll(ModManifest.UniqueID + "_DynamicPatcher");
             }
         }
     }

--- a/BETAS/BETAS.cs
+++ b/BETAS/BETAS.cs
@@ -96,7 +96,7 @@ namespace BETAS
         private void InitializePatcher(object? sender, UpdateTickedEventArgs e)
         {
             if (e.Ticks < 4 || DynamicPatcher.IsInitialized) return;
-            Log.Warn("Initializing patcher...");
+            Log.Trace("Initializing patcher...");
             DynamicPatcher.Initialize(ModManifest);
             Helper.Events.GameLoop.UpdateTicked -= InitializePatcher;
         }

--- a/BETAS/DynamicPatcher.cs
+++ b/BETAS/DynamicPatcher.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using BETAS.Helpers;
+using BETAS.Models;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Triggers;
+using Type = System.Type;
+
+namespace BETAS;
+
+public class DynamicPatcher
+{
+    public static Harmony DynamicHarmony { get; set; } = null!;
+
+    public static Dictionary<string, KeyValuePair<MethodBase, List<DynamicPatch>>> Prefixes { get; set; } =
+        new Dictionary<string, KeyValuePair<MethodBase, List<DynamicPatch>>>();
+
+    public static Dictionary<string, KeyValuePair<MethodBase, List<DynamicPatch>>> Postfixes { get; set; } =
+        new Dictionary<string, KeyValuePair<MethodBase, List<DynamicPatch>>>();
+
+    public static bool IsInitialized;
+
+    public static void Initialize(IManifest manifest)
+    {
+        DynamicHarmony = new Harmony($"{manifest.UniqueID}_DynamicPatcher");
+        var AllPatches =
+            BETAS.ModHelper.GameContent.Load<List<DynamicPatch>>("Spiderbuttons.BETAS/HarmonyPatches");
+
+        if (AllPatches.Count == 0)
+        {
+            Log.Debug("No patches found.");
+            return;
+        }
+
+        foreach (var patch in AllPatches.Where(p =>
+                     p.Action is not null || p.Actions is not null || p.ResultOperation is not null))
+        {
+            var fullName =
+                $"{patch.Target.Type}.{(patch.Target.IsGetter ? "get_" : patch.Target.IsSetter ? "set_" : "")}{patch.Target.Method}, {patch.Target.Assembly}";
+            var patchType = patch.PatchType.Equals("Prefix", StringComparison.OrdinalIgnoreCase) ? Prefixes : Postfixes;
+            if (patchType.ContainsKey(fullName))
+            {
+                patchType[fullName].Value.Add(patch);
+                continue;
+            }
+
+            var patchMethod = GetMethodFromString(patch.Target, out string error);
+            if (patchMethod is null)
+            {
+                Log.Error($"failed to get method from Target in dynamic patch '{patch.Id}': {error}");
+                continue;
+            }
+
+            patchType.TryAdd(fullName,
+                new KeyValuePair<MethodBase, List<DynamicPatch>>(patchMethod, new List<DynamicPatch> { patch }));
+        }
+
+        var dynFactory = AccessTools.Method(typeof(DynamicPatcher), nameof(DynamicFactory));
+        try
+        {
+            foreach (var prefix in Prefixes)
+            {
+                DynamicHarmony.Patch(original: prefix.Value.Key, prefix: new HarmonyMethod(dynFactory));
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to dynamically patch prefixes: {ex}");
+        }
+
+        try
+        {
+            foreach (var postfix in Postfixes)
+            {
+                DynamicHarmony.Patch(original: postfix.Value.Key, postfix: new HarmonyMethod(dynFactory));
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to dynamically patch postfixes: {ex}");
+        }
+
+        IsInitialized = true;
+    }
+
+    public static DynamicMethod DynamicFactory(MethodBase method)
+    {
+        if (method is not MethodInfo info)
+        {
+            Log.Warn("DynamicFactory was called with a non-MethodInfo object");
+            return null;
+        }
+        var methodFullName = $"{info?.DeclaringType}.{info?.Name}, {info?.DeclaringType?.Assembly.GetName().Name}";
+        if (!Prefixes.TryGetValue(methodFullName, out var patches))
+        {
+            if (!Postfixes.TryGetValue(methodFullName, out patches))
+            {
+                Log.Warn($"No dynamic patches found for method '{methodFullName}'");
+                return null;
+            }
+        }
+
+        if (!TryGetMethodInfo(method, out var returnType, out var declaringType, out var parameterList,
+                out var parseMethod))
+        {
+            return null;
+        }
+        
+        var paramTypes = parameterList.Select(p => p.ParameterType).ToArray();
+        // add returnType to beginning of list if not void
+        if (returnType != typeof(void)) paramTypes = new[] { returnType.MakeByRefType() }.Concat(paramTypes).ToArray();
+
+        DynamicMethod dynamicMethod =
+            new DynamicMethod($"SPU_{info?.Name}_{patches.Value.First().PatchType}", typeof(void), paramTypes, declaringType);
+
+        if (returnType != typeof(void)) dynamicMethod.DefineParameter(1, ParameterAttributes.None, "__result");
+        foreach (var param in parameterList)
+        {
+            dynamicMethod.DefineParameter(param.Position + (returnType != typeof(void) ? 2 : 1), param.Attributes, param.ToString().Split(" ")[1]);
+        }
+
+        ILGenerator il = dynamicMethod.GetILGenerator();
+
+        foreach (var patchInfo in patches.Value)
+        {
+            Log.Warn($"Adding {patchInfo.PatchType} dynamic patch '{patchInfo.Id}' to method '{info?.Name}'");
+            var skipBecauseConditionsLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldstr, patchInfo.Condition ?? "true");
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Call, AccessTools.Method(typeof(GameStateQuery), nameof(GameStateQuery.CheckConditions),
+                new Type[]
+                {
+                    typeof(string), typeof(GameLocation), typeof(Farmer), typeof(Item), typeof(Item), typeof(Random),
+                    typeof(HashSet<string>)
+                }));
+            il.Emit(OpCodes.Brfalse, skipBecauseConditionsLabel);
+
+            if (patchInfo.ResultOperation is not null && returnType != typeof(void))
+            {
+                // if ResultOperation.Operation is "Set" then set the first parameter, __result, to the value of ResultOperation.Value after running it through the parseMethod
+                
+                var opCode = returnType switch
+                {
+                    { IsPrimitive: true } => returnType switch
+                    {
+                        { IsValueType: true } => returnType switch
+                        {
+                            { IsEnum: true } => OpCodes.Stind_Ref,
+                            _ => OpCodes.Stind_I4
+                        },
+                        _ => OpCodes.Stind_Ref
+                    },
+                    _ => OpCodes.Stind_Ref
+                };
+
+                il.Emit(info.IsStatic ? OpCodes.Ldarg_1 : OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldstr, patchInfo.ResultOperation.Value);
+                il.Emit(OpCodes.Call, parseMethod);
+                il.Emit(opCode);
+            }
+
+            if (patchInfo.Action is not null)
+            {
+                il.Emit(OpCodes.Ldstr, patchInfo.Id);
+                il.Emit(OpCodes.Ldstr, patchInfo.Action);
+                il.Emit(OpCodes.Call,
+                    AccessTools.Method(typeof(DynamicPatcher), nameof(TryRunSimplePatchAction)));
+            }
+            else if (patchInfo.Actions is not null)
+            {
+                foreach (var action in patchInfo.Actions)
+                {
+                    il.Emit(OpCodes.Ldstr, patchInfo.Id);
+                    il.Emit(OpCodes.Ldstr, action);
+                    il.Emit(OpCodes.Call,
+                        AccessTools.Method(typeof(DynamicPatcher), nameof(TryRunSimplePatchAction)));
+                }
+            }
+
+            il.MarkLabel(skipBecauseConditionsLabel);
+        }
+
+        il.Emit(OpCodes.Ret);
+
+        return dynamicMethod;
+    }
+
+    public static void TryRunSimplePatchAction(string patchID, string action)
+    {
+        if (TriggerActionManager.TryRunAction(action, out var error, out var ex)) return;
+        Log.Warn($"Failed to run action '{action}' for dynamic patch '{patchID}': {error}");
+    }
+
+    public static bool TryGetMethodInfo(MethodBase method, out Type returnType, out Type declaringType,
+        out ParameterInfo[] parameterList, out MethodInfo parseMethod)
+    {
+        if (method is not MethodInfo info)
+        {
+            returnType = typeof(void);
+            declaringType = null;
+            parameterList = null;
+            parseMethod = null;
+            return false;
+        }
+
+        returnType = info.ReturnType;
+        declaringType = info.DeclaringType;
+        parameterList = info.GetParameters();
+        parseMethod = returnType != typeof(void)
+            ? returnType.GetMethod("Parse", new Type[] { typeof(string) })
+            : null;
+
+        return true;
+    }
+
+    public static MethodInfo GetMethodFromString(TargetMethod target, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(target.Type))
+        {
+            error = "the type name can't be empty";
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(target.Method))
+        {
+            error = "the method name can't be empty";
+            return null;
+        }
+
+        var methodName = $"{target.Type}:{target.Method}";
+        var paramTypes = target.Parameters.Select(AccessTools.TypeByName).ToArray();
+        if (paramTypes.Any(t => t is null))
+        {
+            error = $"could not find one or more parameter types for method '{methodName}'";
+            return null;
+        }
+
+        var result = target switch
+        {
+            { IsGetter: true } => AccessTools.PropertyGetter(methodName),
+            { IsSetter: true } => AccessTools.PropertySetter(methodName),
+            _ => AccessTools.Method(methodName, paramTypes.Length == 0 ? null : paramTypes)
+        };
+
+        if (result is not null)
+        {
+            error = null;
+            return result;
+        }
+
+        error = paramTypes.Length switch
+        {
+            0 => $"could not find method '{target.Method}' with no parameters on type '{target.Type}' in assembly '{target.Assembly}'",
+            _ => $"could not find method '{target.Method}' with the specified parameters ({string.Join(", ", target.Parameters)}) on type '{target.Type}' in assembly '{target.Assembly}'"
+        };
+        return null;
+    }
+}

--- a/BETAS/DynamicPatcher.cs
+++ b/BETAS/DynamicPatcher.cs
@@ -34,7 +34,7 @@ public class DynamicPatcher
 
         if (AllPatches.Count == 0)
         {
-            Log.Debug("No patches found.");
+            Log.Trace("No patches found.");
             return;
         }
 
@@ -96,7 +96,7 @@ public class DynamicPatcher
         Postfixes.Clear();
         DynamicHarmony.UnpatchAll(DynamicHarmony.Id);
 
-        Log.Debug("DynamicPatcher has been reset.");
+        Log.Trace("DynamicPatcher has been reset.");
 
         Initialize(manifest);
     }
@@ -144,9 +144,7 @@ public class DynamicPatcher
 
         foreach (var patchInfo in patches.Value)
         {
-            Log.Warn($"Adding {patchInfo.PatchType} dynamic patch '{patchInfo.Id}' to method '{info?.Name}'");
-            il.Emit(OpCodes.Ldstr, "Beginning of patch.");
-            il.Emit(OpCodes.Call, AccessTools.Method(typeof(Log), nameof(Log.Debug), null, new Type[] { typeof(string) }));
+            Log.Trace($"Adding {patchInfo.PatchType} dynamic patch '{patchInfo.Id}' to method '{info?.Name}'");
             var skipBecauseConditionsLabel = il.DefineLabel();
             var endOfResultChangeLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldstr, patchInfo.Condition ?? "true");
@@ -234,9 +232,7 @@ public class DynamicPatcher
                         AccessTools.Method(typeof(DynamicPatcher), nameof(TryRunSimplePatchAction)));
                 }
             }
-
-            il.Emit(OpCodes.Ldstr, "End of patch.");
-            il.Emit(OpCodes.Call, AccessTools.Method(typeof(Log), nameof(Log.Debug), null, new Type[] { typeof(string) }));
+            
             il.Emit(OpCodes.Nop);
             il.MarkLabel(skipBecauseConditionsLabel);
         }

--- a/BETAS/DynamicPatcher.cs
+++ b/BETAS/DynamicPatcher.cs
@@ -222,7 +222,8 @@ public class DynamicPatcher
                 il.Emit(OpCodes.Call,
                     AccessTools.Method(typeof(DynamicPatcher), nameof(TryRunSimplePatchAction)));
             }
-            else if (patchInfo.Actions is not null)
+            
+            if (patchInfo.Actions is not null)
             {
                 foreach (var action in patchInfo.Actions)
                 {

--- a/BETAS/Models/DynamicPatch.cs
+++ b/BETAS/Models/DynamicPatch.cs
@@ -17,7 +17,7 @@ public class DynamicPatch
     public string Condition = null;
 
     [ContentSerializer(Optional = true)]
-    public ResultOp ResultOperation = null;
+    public ResultOp ChangeResult = null;
     
     [ContentSerializer(Optional = true)]
     public string Action = null;

--- a/BETAS/Models/DynamicPatch.cs
+++ b/BETAS/Models/DynamicPatch.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework.Content;
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework.Content;
 
 namespace BETAS.Models;
 
@@ -14,14 +15,14 @@ public class DynamicPatch
     public string PatchType;
 
     [ContentSerializer(Optional = true)]
-    public string Condition = null;
+    public string Condition;
 
     [ContentSerializer(Optional = true)]
     public ResultOp ChangeResult = null;
     
     [ContentSerializer(Optional = true)]
-    public string Action = null;
+    public string Action;
 
     [ContentSerializer(Optional = true)]
-    public string[] Actions = null;
+    public List<string> Actions;
 }

--- a/BETAS/Models/DynamicPatch.cs
+++ b/BETAS/Models/DynamicPatch.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Xna.Framework.Content;
+
+namespace BETAS.Models;
+
+public class DynamicPatch
+{
+    [ContentSerializer(Optional = false)]
+    public string Id;
+
+    [ContentSerializer(Optional = false)]
+    public TargetMethod Target;
+
+    [ContentSerializer(Optional = false)]
+    public string PatchType;
+
+    [ContentSerializer(Optional = true)]
+    public string Condition = null;
+
+    [ContentSerializer(Optional = true)]
+    public ResultOp ResultOperation = null;
+    
+    [ContentSerializer(Optional = true)]
+    public string Action = null;
+
+    [ContentSerializer(Optional = true)]
+    public string[] Actions = null;
+}

--- a/BETAS/Models/ResultOp.cs
+++ b/BETAS/Models/ResultOp.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Xna.Framework.Content;
+
+namespace BETAS.Models;
+
+public class ResultOp
+{
+    [ContentSerializer(Optional = false)]
+    public string Operation;
+
+    [ContentSerializer(Optional = false)]
+    public string Value;
+}

--- a/BETAS/Models/TargetMethod.cs
+++ b/BETAS/Models/TargetMethod.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Xna.Framework.Content;
+
+namespace BETAS.Models;
+
+public class TargetMethod
+{
+    [ContentSerializer(Optional = false)]
+    public string Type;
+
+    [ContentSerializer(Optional = false)]
+    public string Method;
+
+    [ContentSerializer(Optional = true)]
+    public string[] Parameters = [];
+
+    [ContentSerializer(Optional = true)]
+    public bool IsGetter = false;
+    
+    [ContentSerializer(Optional = true)]
+    public bool IsSetter = false;
+
+    [ContentSerializer(Optional = true)]
+    public string Assembly = "Stardew Valley";
+}


### PR DESCRIPTION
Allows for defining very simple Harmony patches that can run Trigger Action actions or change the results of value types for a function using Content Patcher patches.